### PR TITLE
queryApply shouldn't wait for job

### DIFF
--- a/src/client/query.c
+++ b/src/client/query.c
@@ -248,11 +248,7 @@ PHP_METHOD(Aerospike, queryApply) {
 		goto CLEANUP;
 	}
 
-	if (aerospike_query_background(as_client, &err, write_policy_p, &query, &job_id) != AEROSPIKE_OK) {
-		goto CLEANUP;
-	}
-
-	if (aerospike_query_wait(as_client, &err, NULL, &query, job_id, 0) == AEROSPIKE_OK) {
+	if (aerospike_query_background(as_client, &err, write_policy_p, &query, &job_id) == AEROSPIKE_OK) {
 		ZVAL_LONG(z_job_id, job_id);
 	}
 


### PR DESCRIPTION
This [commentary](https://github.com/aerospike/aerospike-client-php/blob/6029d51d52a0b1f24adec0921ddf757de8a6def6/src/client/query.c#L162) says that queryApply method of client should use background query. It is expected behavior because of [phpdoc class](https://github.com/aerospike/aerospike-client-php/blob/6029d51d52a0b1f24adec0921ddf757de8a6def6/doc/phpdoc/aerospike.php#L2322). So this fix removes waiting for job is done.