### PR TITLE
Operate delete

### DIFF
--- a/doc/phpdoc/aerospike.php
+++ b/doc/phpdoc/aerospike.php
@@ -1113,6 +1113,9 @@ class Aerospike {
      *   op => Aerospike::OPERATOR_TOUCH
      *   ttl => a positive integer value to set as time-to-live for the record
      *
+     * Delete Operation:
+     *   op => Aerospike::OPERATOR_DELETE
+     *
      * List Append Operation:
      *   op => Aerospike::OP_LIST_APPEND,
      *   bin =>  "events",
@@ -1483,6 +1486,9 @@ class Aerospike {
      *                  (only combines with read operations)
      *   op => Aerospike::OPERATOR_TOUCH
      *   ttl => a positive integer value to set as time-to-live for the record
+     *
+     * Delete Operation:
+     *   op => Aerospike::OPERATOR_DELETE
      *
      * List Append Operation:
      *   op => Aerospike::OP_LIST_APPEND,
@@ -4672,6 +4678,11 @@ class Aerospike {
      * @const OPERATOR_TOUCH
      */
     const OPERATOR_TOUCH = "OPERATOR_TOUCH";
+    /**
+     * delete operator for the operate() method
+     * @const OPERATOR_DELETE
+     */
+    const OPERATOR_DELETE = "OPERATOR_DELETE";
 
     // List operation constants
 

--- a/doc/security/aerospike_operateOrdered.md
+++ b/doc/security/aerospike_operateOrdered.md
@@ -58,6 +58,9 @@ Touch Operation: reset the time-to-live of the record and increment its generati
   op => Aerospike::OPERATOR_TOUCH
   ttl => a positive integer value to set as time-to-live for the record
 
+Delete Operation:
+  op => Aerospike::OPERATOR_DELETE
+
 List Append Operation:
   op => Aerospike::OP_LIST_APPEND,
   bin =>  "events",

--- a/src/register_constants.c
+++ b/src/register_constants.c
@@ -57,6 +57,7 @@ static AerospikeGeneralLongConstant aerospike_general_long_constants[] = {
 	{ AS_OPERATOR_PREPEND,             "OPERATOR_PREPEND"             },
 	{ AS_OPERATOR_APPEND,              "OPERATOR_APPEND"              },
 	{ AS_OPERATOR_TOUCH,               "OPERATOR_TOUCH"               },
+	{ AS_OPERATOR_DELETE,              "OPERATOR_DELETE"              },
 	{ AS_INDEX_GEO2DSPHERE,            "INDEX_GEO2DSPHERE"            },
 	{ OP_LIST_APPEND,       		   "OP_LIST_APPEND"               },
 	{ OP_LIST_MERGE,       		       "OP_LIST_MERGE"                },

--- a/src/tests/OperateOrdered.inc
+++ b/src/tests/OperateOrdered.inc
@@ -211,6 +211,46 @@ class OperateOrdered extends AerospikeTestCommon
 
     /**
      * @test
+     * Positive scenario : operateOrdered() with read and delete operations.
+     *
+     * @pre
+     * Connect using aerospike object to the specified node
+     *
+     * @post
+     * newly initialized Aerospike objects
+     *
+     * @remark
+     * Variants: OO (normal_004)
+     *
+     * @test_plans{1.1}
+     */
+    function normal_006() {
+        $key = $this->db->initKey("test", "demo", "pk459");
+        $this->keys[] = $key;
+        $status = $this->db->put($key, ["for_del_bin" => "testVal"]);
+        if ($status != Aerospike::OK)
+            return $status;
+        $operations = array(
+            array("op" => Aerospike::OPERATOR_READ, "bin" => "for_del_bin"),
+            array("op" => Aerospike::OPERATOR_DELETE),
+        );
+        $status = $this->db->operateOrdered($key, $operations, $returned);
+        if ($status != Aerospike::OK) {
+            return $status;
+        }
+
+        if (!$returned || $returned[0][0] != "for_del_bin" || $returned[0][1] != "testVal") {
+            return Aerospike::ERR_CLIENT;
+        }
+
+        $status = $this->db->get($key, $rec);
+        if ($status == Aerospike::ERR_RECORD_NOT_FOUND)
+            return Aerospike::OK;
+        return Aerospike::ERR_CLIENT;
+    }
+
+    /**
+     * @test
      * Negative scenario : operateOrdered() with string value is passed in place of an keys array.
      *
      * @pre

--- a/src/tests/aerospikeConstantTest.php
+++ b/src/tests/aerospikeConstantTest.php
@@ -98,6 +98,7 @@ final class constantRegistrationTest extends TestCase {
         "OPERATOR_PREPEND",
         "OPERATOR_APPEND",
         "OPERATOR_TOUCH",
+        "OPERATOR_DELETE",
         "INDEX_GEO2DSPHERE",
         "OP_LIST_APPEND",
         "OP_LIST_MERGE",

--- a/src/tests/phpt/OperateOrdered/normal_006.phpt
+++ b/src/tests/phpt/OperateOrdered/normal_006.phpt
@@ -1,0 +1,14 @@
+--TEST--
+operateOrdered() with read and delete operations.
+
+--DESCRIPTION--
+This testcase will test for operateOrdered() with OPERATOR_READ and OPERATOR_DELETE on the same key
+
+--FILE--
+<?php
+include dirname(__FILE__)."/../../astestframework/astest-phpt-loader.inc";
+aerospike_phpt_runtest("OperateOrdered", "normal_006");
+?>
+
+--EXPECT--
+OK


### PR DESCRIPTION
Added support for new OPERATOR_DELETE operator for operate/operateOrdered which removes the whole specified key.