### PR TITLE
Remove trailing php tag

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -17,5 +17,3 @@ if (!is_array($autoloaders) || !array_key_exists('Aerospike\\Bytes', $autoloader
         }
     });
 }
-
-?>

--- a/src/Bytes.php
+++ b/src/Bytes.php
@@ -94,3 +94,4 @@ class Bytes implements \Serializable
     }
 
 }
+

--- a/src/GeoJSON/Autoloader.php
+++ b/src/GeoJSON/Autoloader.php
@@ -58,4 +58,3 @@ class Autoloader
     }
 }
 
-?>

--- a/src/GeoJSON/GeoJSON.php
+++ b/src/GeoJSON/GeoJSON.php
@@ -77,4 +77,4 @@ class GeoJSON implements \Aerospike\GeoJSON\Serializable
         return new \Aerospike\GeoJSON($geo_obj);
     }
 }
-?>
+

--- a/src/GeoJSON/Serializable.php
+++ b/src/GeoJSON/Serializable.php
@@ -40,4 +40,4 @@ interface Serializable extends \JsonSerializable
 
     public function jsonSerialize();
 }
-?>
+


### PR DESCRIPTION
Empty space after php tag causes output to client which is usually not expected.
It is completely normal to leave php code unclosed.