### PR TITLE
Fix travis build due to missing nsup-period

### DIFF
--- a/.travis/aerospike.conf
+++ b/.travis/aerospike.conf
@@ -49,5 +49,6 @@ namespace test {
   replication-factor 2
   memory-size 1G
   default-ttl 30d # 30 days, use 0 to never expire/evict.
+  nsup-period 1h
   storage-engine memory
 }


### PR DESCRIPTION
Latest aerospike changed the way expring namespaces must be configured.