### PR TITLE
Adding use_services-alternate parameter to php-client

### DIFF
--- a/doc/phpdoc/aerospike.php
+++ b/doc/phpdoc/aerospike.php
@@ -173,6 +173,7 @@ class Aerospike {
      * * Aerospike::OPT_POLICY_REPLICA
      * * Aerospike::OPT_POLICY_READ_MODE_AP
      * * Aerospike::OPT_POLICY_READ_MODE_SC
+     * * Aerospike::USE_SERVICES_ALTERNATE
      * * Aerospike::OPT_READ_DEFAULT_POL An array of default policies for read operations.
      * * Aerospike::OPT_WRITE_DEFAULT_POL An array of default policies for write operations.
      * * AEROSPIKE::OPT_REMOVE_DEFAULT_POL An array of default policies for remove operations.
@@ -4133,6 +4134,13 @@ class Aerospike {
      * @const OPT_QUERY_NOBINS boolean value (default: false)
      */
     const OPT_QUERY_NOBINS = "OPT_QUERY_NOBINS";
+
+    /**
+     * Flag to signify if "services-alternate" should be used instead of "services"
+     *
+     * @const USE_SERVICES_ALTERNATE boolean value (default: false)
+     */
+    const USE_SERVICES_ALTERNATE = "USE_SERVICES_ALTERNATE";
 
     /**
      * Revert to the older batch-direct protocol, instead of batch-index.

--- a/src/client/aerospike_class.c
+++ b/src/client/aerospike_class.c
@@ -808,6 +808,13 @@ static as_status set_policy_defaults_from_hash(as_config* config, AerospikeClien
 		}
 		config->conn_timeout_ms = Z_LVAL_P(policy_zval);
 	}
+	policy_zval = zend_hash_index_find(policy_hash, USE_SERVICES_ALTERNATE);
+	if (policy_zval) {
+		if ((Z_TYPE_P(policy_zval) != IS_TRUE) && (Z_TYPE_P(policy_zval) != IS_FALSE)) {
+			return AEROSPIKE_ERR_PARAM;
+		}
+			config->use_services_alternate = Z_LVAL_P(policy_zval);
+	}
 
 	policy_zval = zend_hash_index_find(policy_hash, OPT_READ_TIMEOUT);
 	if (policy_zval) {

--- a/src/include/php_aerospike_types.h
+++ b/src/include/php_aerospike_types.h
@@ -131,6 +131,7 @@ enum Aerospike_opt_keys {
 	OPT_POLICY_COMMIT_LEVEL, /* set to one of Aerospike::POLICY_COMMIT_LEVEL_*                                */
 	OPT_TTL,                 /* set to time-to-live of the record in seconds                                  */
 	USE_BATCH_DIRECT,        /* use new batch index protocol if server supports it                            */
+      USE_SERVICES_ALTERNATE,  /* boolean value, default: false                                                 */
 	COMPRESSION_THRESHOLD,   /* Minimum record size beyond which it is compressed and sent to the server      */
 	OPT_POLICY_DURABLE_DELETE, /* set to true to enable durable delete for the operation                       */
 	OPT_SOCKET_TIMEOUT,       /* Socket timeout to be applied to server as well as client */

--- a/src/register_policy_constants.c
+++ b/src/register_policy_constants.c
@@ -50,6 +50,7 @@ AerospikeOptionConstant aerospike_option_constants[] = {
 	{ OPT_POLICY_READ_MODE_SC               ,   "OPT_POLICY_READ_MODE_SC"           },
 	{ OPT_POLICY_COMMIT_LEVEL               ,   "OPT_POLICY_COMMIT_LEVEL"           },
 	{ OPT_TTL                               ,   "OPT_TTL"                           },
+	{ USE_SERVICES_ALTERNATE                ,   "USE_SERVICES_ALTERNATE"            },
 	{ USE_BATCH_DIRECT                      ,   "USE_BATCH_DIRECT"                  },
 	{ COMPRESSION_THRESHOLD                 ,   "COMPRESSION_THRESHOLD"             },
 	{ AS_POLICY_RETRY_NONE                  ,   "POLICY_RETRY_NONE"                 },

--- a/src/tests/aerospikeConstantTest.php
+++ b/src/tests/aerospikeConstantTest.php
@@ -23,6 +23,7 @@ final class constantRegistrationTest extends TestCase {
         "OPT_POLICY_READ_MODE_SC",
         "OPT_POLICY_COMMIT_LEVEL",
         "OPT_TTL",
+        "USE_SERVICES_ALTERNATE",
         "USE_BATCH_DIRECT",
         "COMPRESSION_THRESHOLD",
         "POLICY_RETRY_NONE",


### PR DESCRIPTION
I created a new Pull request because this is cleaner but no big changes it should be ready.
This parameter exists in the c client but it's not available by default in the php client this pull request will make it work by adding it to the options array that can be specified inside the config array like the following example:
```php
$config = [
	"hosts" => [
           ['addr' => '192.168.57.101', 'port' => 3000]],
	"options" => [
          // Flag to signify if "services-alternate" should be used instead of "services" Default: false
	  Aerospike::USE_SERVICES_ALTERNATE => true
        ],
];
$db = new Aerospike($config);

// records are identified as a (namespace, set, primary-key) tuple
$key = $db->initKey("infosphere", "characters", 1234);

// the record and its bins are created and updated similar to an array
$put_vals = [ "name" => "Scruffy", "Occupation" => "The Janitor" ];
$db->put($key, $put_vals);

// record bins can hold complex types such as arrays
$update_vals = [
  "quotes" => [
    "I'm Scruffy. The janitor.",
    "I'm on break.",
    "Scruffy's gonna die like he lived."]];
$db->put($key, $update_vals);

// read selected bins from a record
$db->get($key, $record, ["name", "quotes"]);

$db->close();
```