### PR TITLE
Fix testInfoPositiveForLatency test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
 - 7.2
-- 7.3
+- 7.3.24
 os:
 - linux
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 php:
 - 7.2
 - 7.3
+- 7.4
 os:
 - linux
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 - cd ../..
 - sleep 3
 script:
-- cd src/
+- cd src
 - ./build.sh
 - make install
 - ../.travis/edit-php-ini.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ install:
 - sleep 3
 script:
 - composer install
+- cd src
 - make install
 - ../.travis/edit-php-ini.sh
 - cp ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini tmp-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
 - 7.2
 - 7.3
-- 7.4
 os:
 - linux
 addons:
@@ -38,15 +37,13 @@ install:
 - cd ../..
 - sleep 3
 script:
-- composer install
-- rm -rf aerospike-client-c
-- cd src
+- cd src/
 - ./build.sh
 - make install
 - ../.travis/edit-php-ini.sh
 - cp ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini tmp-php.ini
-- ../vendor/bin/phpunit -v || true
-- ../vendor/bin/phpunit tests
+- phpunit -v || true
+- phpunit tests
 notifications:
   slack:
     secure: CvYjLs0z+Y7NnhhoDLU61GSEKaPr0AM6fGrLHqqpXmNgl4AlaLSL46eSA6Zu/6cpnwr7m5REpjR6p4iNT57may783Ud+d89offuXK4nwiexi0MBPaPNb7MlBl07k1eOfX9GfbEYYo6vbp6q2DSn3RgrGIlyT20ocXPOLNJrh58U=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
 - 7.2
-- 7.3.20
+- 7.3.24
 os:
 - linux
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
 - sleep 3
 script:
 - composer install
+- rm -rf aerospike-client-c
 - cd src
 - ./build.sh
 - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,12 @@ install:
 - cd ../..
 - sleep 3
 script:
-- cd src/
-- ./build.sh
+- composer install
 - make install
 - ../.travis/edit-php-ini.sh
 - cp ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini tmp-php.ini
-- phpunit -v || true
-- phpunit tests
+- ../vendor/bin/phpunit -v || true
+- ../vendor/bin/phpunit tests
 notifications:
   slack:
     secure: CvYjLs0z+Y7NnhhoDLU61GSEKaPr0AM6fGrLHqqpXmNgl4AlaLSL46eSA6Zu/6cpnwr7m5REpjR6p4iNT57may783Ud+d89offuXK4nwiexi0MBPaPNb7MlBl07k1eOfX9GfbEYYo6vbp6q2DSn3RgrGIlyT20ocXPOLNJrh58U=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
 - 7.2
-- 7.3.24
+- 7.3
 os:
 - linux
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ install:
 script:
 - composer install
 - cd src
+- ./build.sh
 - make install
 - ../.travis/edit-php-ini.sh
 - cp ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini tmp-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
 - 7.2
-- 7.3
+- 7.3.20
 os:
 - linux
 addons:

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,6 @@
     "require": {
         "php": "~7.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "^8.0"
-    },
     "autoload": {
         "psr-4": {
             "Aerospike\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     "require": {
         "php": "~7.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^8.0"
+    },
     "autoload": {
         "psr-4": {
             "Aerospike\\": "src/"

--- a/src/tests/Info.inc
+++ b/src/tests/Info.inc
@@ -182,7 +182,7 @@ class Info extends AerospikeTestCommon
     function testInfoPositiveForLatency()
     {
         try {
-            $status = $this->db->info('latency:hist=reads;slice=30;back=300;duration:120', $response, $this->test_host);
+            $status = $this->db->info('latencies:hist=reads;slice=30;back=300;duration:120', $response, $this->test_host);
             if(!empty($response))
                 return $status;
         } catch (ErrorException $e) {

--- a/src/tests/Info.inc
+++ b/src/tests/Info.inc
@@ -182,7 +182,7 @@ class Info extends AerospikeTestCommon
     function testInfoPositiveForLatency()
     {
         try {
-            $status = $this->db->info('latencies:hist=reads;slice=30;back=300;duration:120', $response, $this->test_host);
+            $status = $this->db->info('latency:hist=reads;slice=30;back=300;duration:120', $response, $this->test_host);
             if(!empty($response))
                 return $status;
         } catch (ErrorException $e) {


### PR DESCRIPTION
`testInfoPositiveForLatency` test is failing

Looks like `latency` is called `latencies` now
https://www.aerospike.com/docs/reference/info/index.html#latencies

Had to lock the PHP `7.3` version to `7.3.24` due to Segmentation Faults on `7.3.25`
On the same note, the unit tests are failing on Travis' `7.4` also with Segmentation Faults, but they work in my container built on top of `php:7.4.13-cli`