### PR TITLE
Update aerospike.php to use `Aerospike::OK` as int

### DIFF
--- a/doc/phpdoc/aerospike.php
+++ b/doc/phpdoc/aerospike.php
@@ -4352,7 +4352,7 @@ class Aerospike {
      *
      * @const OK Success
      */
-    const OK = "AEROSPIKE_OK";
+    const OK = 0;
 
     // -10 - -1 - Client Errors
 


### PR DESCRIPTION
As per C header file https://github.com/aerospike/aerospike-client-c/blob/648cb21e880e3039a086e3c412f19a7b4e3fd116/src/include/aerospike/as_status.h#L106-L113
And actual behavior

```
php > var_dump(phpversion());
string(6) "7.3.18"
php > var_dump(phpversion('aerospike'));
string(5) "7.5.2"
php > var_dump(Aerospike::OK);
int(0)
```