### PR TITLE
Update C Client to 4.6.24 for compatibility with latest server

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -17,7 +17,7 @@
 
 export CLIENTREPO_3X=${PWD}/../aerospike-client-c
 
-export AEROSPIKE_C_VERSION=${AEROSPIKE_C_CLIENT:-4.6.9}
+export AEROSPIKE_C_VERSION=${AEROSPIKE_C_CLIENT:-4.6.24}
 export DOWNLOAD_C_CLIENT=${DOWNLOAD_C_CLIENT:-1}
 export LUA_USRPATH=${LUA_USRPATH:-/usr/local/aerospike/usr-lua}
 


### PR DESCRIPTION
Current build has compatibility issues with the latest version of Aerospike Server. `getMany()` was broken after a recent upgrade to Aerospike Server 6. Updating C client to 4.6.24 fixes `getMany()`, and the client appears to be functioning normally again.